### PR TITLE
Moving the API calls to a new .py file

### DIFF
--- a/apiCalls.py
+++ b/apiCalls.py
@@ -1,0 +1,50 @@
+# Http integration managment
+# generic verion of a http request, formats to request well.
+def request():
+	pass
+
+# generic version of a http response, formats to respond well.
+def response():
+	pass
+
+
+
+# Note Searching
+def listNotes():
+	#by created date, modified date, title
+	pass
+
+def searchNotes():
+	#by content, title, tags, date
+	pass
+
+
+
+# Note Classification Suite
+def addTag():
+	# Makes a list of tags that should be added to the title, does not need to check if tags exist
+	pass
+
+def deletetag():
+	# Delete a tag from a note
+	pass
+
+def listTags():
+	# Lists tags of all notes
+	pass 
+
+
+
+# Note creation suite
+def createNote():
+	#addTag()
+	pass 
+
+def deleteNote():
+	pass
+
+def addContent():
+	# This should add to an existing note
+	pass 
+
+

--- a/frontend.py
+++ b/frontend.py
@@ -2,6 +2,8 @@ import os
 import shutil
 import string
 
+import apiCalls
+
 # Base frontend functionality
 def clearConsole():
 	os.system('cls' if os.name == 'nt' else 'clear')
@@ -34,59 +36,6 @@ def lineBreak(columns, color):
 	for i in range(1,columns):
 		line += '-'
 	printColor(line, color, "")
-
-
-
-# Http integration managment
-# generic verion of a http request, formats to request well.
-def request():
-	pass
-
-# generic version of a http response, formats to respond well.
-def response():
-	pass
-
-
-
-# Note Searching
-def listNotes():
-	#by created date, modified date, title
-	pass
-
-def searchNotes():
-	#by content, title, tags, date
-	pass
-
-
-
-# Note Classification Suite
-def addTag():
-	# Makes a list of tags that should be added to the title, does not need to check if tags exist
-	pass
-
-def deletetag():
-	# Delete a tag from a note
-	pass
-
-def listTags():
-	# Lists tags of all notes
-	pass 
-
-
-
-# Note creation suite
-def createNote():
-	#addTag()
-	pass 
-
-def deleteNote():
-	pass
-
-def addContent():
-	# This should add to an existing note
-	pass 
-
-
 
 # States of operation
 def printStartScreen():


### PR DESCRIPTION
This should be pretty quick: I moved the API functions to their own file outside the frontend.py file because a) the frontend file was getting way too long, and b) I can't run the frontend file because I'm stuck on Python 3.9, so this will allow me to actually test stuff. I put an import function into frontend.py so we should just be able to write in basic calls once we finish the functions