### PR TITLE
Search testing and API docs response changes

### DIFF
--- a/API.md
+++ b/API.md
@@ -53,23 +53,30 @@ The request dictionary keys required for a call to the backend depends on the en
 ```
 Notice that the body sections in this documentation are specifying the keys for this request. 
 ## Responses: A design for response dictionary
-For lists and search (GET) requests there are JSON dictionary responses. Those dictionaries should have the following format.
+For lists and search (GET) requests there are nested list responses. Those nested lists depend on the request you are sending and the endpoint you are sending it to.
 ```
-{
-	"title1" : [
-		"return_field1": "field1_value",
-		"return_field2": "field2_value"
-	],
-	"title2" : [
-		"return_field1": "field1_value",
-		"return_field2": "field2_value"
-	],
-	"title3" : [
-		"return_field1": "field1_value",
-		"return_field2": "field2_value"
-	]
-}
+[
+	["object1_field1_value",
+	"object1_field2_value",
+	"object1_field3_value"],
+	["object2_field1_value",
+	"object2_field2_value",
+	"object2_field3_value"],
+	["object3_field1_value",
+	"object3_field2_value",
+	"object3_field3_value"]
+	...
+]
 ```
+For /notes/search GET methods the specific fields 1, 2, 3 etc. to return are defined by the `result_fields` list in the request body.
+If title is not provided as a `return_fields` value then it is automatically added at the end.
+
+For /tags/search the specific fields are automatically title and tag in that order.
+
+For /notes/list GET methods only one field other than title is allowed to be returned. That field is defined by the `list_field` value in the request body.
+
+For /tags/list the specific fields are automatically title and tag in that order.
+
 ## Feature 4: List notes
 This is an interesting feature which seems vague and confusing. We implement it like this.
 We interpret the `specs.md` file to mean that this feature should list all of the notes.

--- a/tests.sh
+++ b/tests.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+# script for running automatic tests with curl
+# run these lines in a different terminal before running this
+# rm note.db
+# flask run
+
+today=$(date '+%Y-%m-%d')
+# create notes
+ curl -H 'Content-Type: application/json' \
+      -d '{"title":"my note"}' \
+      -X POST \
+      http://127.0.0.1:5000/notes
+
+curl -H 'Content-Type: application/json' \
+      -d '{"title": "your note",
+			"content": "Today in class we will..."}' \
+      -X POST \
+      http://127.0.0.1:5000/notes
+
+# tags create
+curl -H 'Content-Type: application/json' \
+      -d '{"title": "your note",
+		"tag": ["fun"]}' \
+      -X POST \
+      http://127.0.0.1:5000/tags
+curl -H 'Content-Type: application/json' \
+      -d '{"title": "my note",
+		"tag": ["boring", "fun"]}' \
+      -X POST \
+      http://127.0.0.1:5000/tags
+
+# notes search
+# return content and search by title
+curl -H 'Content-Type: application/json' \
+      -d '{"search_field":"title",
+    	"query":"your note",
+    	"return_fields":["content"]}' \
+      -X GET \
+      http://127.0.0.1:5000/notes/search
+# return created date and search by created date
+curl -H 'Content-Type: application/json' \
+      -d '{"search_field":"created_date",
+    	"query":"'"$today"'",
+    	"return_fields":["created_date"]}' \
+      -X GET \
+      http://127.0.0.1:5000/notes/search
+# return modified date and title search by modified date
+curl -H 'Content-Type: application/json' \
+      -d '{"search_field":"modified_date",
+    	"query":"'"$today"'",
+    	"return_fields":["modified_date", "title"]}' \
+      -X GET \
+      http://127.0.0.1:5000/notes/search
+# tag list
+curl -H 'Content-Type: application/json' \
+      -d '{}' \
+      -X GET \
+      http://127.0.0.1:5000/tags/list
+# tags search
+# >1 match
+curl -H 'Content-Type: application/json' \
+      -d '{"query": "boring"}' \
+      -X GET \
+      http://127.0.0.1:5000/tags/search
+# ==1 match
+curl -H 'Content-Type: application/json' \
+      -d '{"query": "fun"}' \
+      -X GET \
+      http://127.0.0.1:5000/tags/search


### PR DESCRIPTION
## Search Testing
1. I fully tested the search API calls, fixing bugs with the date strings comparisons
2. I added jsonification to all of our list and search endpoints. This changes the responses that we will get. It looks like the frontend has not yet written code that expects certain formats from those responses though, so this will not be a breaking change (see the section below)
3. I created a `tests.sh` file. This is a script that uses the `curl` command line utility to automatically run calls on our API. This way you can all see the exact tests I ran in postman. If this script throws errors while you run it then the API calls inside of it are failing. Feel free to add your tests to this file. I hope the `curl` calls make sense to you. If you choose to use this script, just add your `curl` calls to it. Then open a seperate terminal and run
```
rm note.db
flask run
``` 
and then in your current terminal simply run `./tests.sh`
## Documentation
Because of the JSONification of our responses, they have changed formatting a little bit. I reflected these changes in the `API.md` file in the "Responses: A design for response dictionary". It turns our the responses are now just nested lists and not dictionaries at all. 