### PR TITLE
Search for a range of dates

### DIFF
--- a/API.md
+++ b/API.md
@@ -101,6 +101,8 @@ body:
 	`'query'` (required): string representing the string to search for in the 'search_field'
 	`'return_fields'` (required): list of strings representing aspects of the notes you want returned back to you
 		- must be in ('modified_date', 'title', 'created_date', 'tag')
+	`'start'` (option): start date for range to search by date within
+	`'end'` (option): end date for range to search by date within
 
 ## Additional Feature 2: Search by title
 Run this with `'search_field': 'title'`

--- a/apiCalls.py
+++ b/apiCalls.py
@@ -17,10 +17,15 @@ def listNotes(listBy):
 	url = "http://127.0.0.1:5000/notes/list"
 	return requests.get(url,headers=header, json={'list_field': listBy})
 
-def searchNotes(field, searchQuery, returnField):
+def searchNotes(field, searchQuery, returnField, start=None, stop=None):
 	#by content, title, tags, date
 	url = "http://127.0.0.1:5000/notes/search"
-	return requests.get(url,headers=header, json={'search_field': field, 'query': searchQuery, 'return_fields': returnField})
+	# conditional check on whether to pass start and stop
+	if field in set('modified_date', 'createNote'):
+		json = {'search_field': field, 'query': searchQuery, 'return_fields': returnField, 'start': start, 'stop': stop}
+	else:
+		json = {'search_field': field, 'query': searchQuery, 'return_fields': returnField}
+	return requests.get(url,headers=header, json=json)
 
 
 

--- a/apiCalls.py
+++ b/apiCalls.py
@@ -1,4 +1,5 @@
 import requests
+from datetime import date
 
 # Http integration managment
 # generic verion of a http request, formats to request well.
@@ -17,7 +18,7 @@ def listNotes(listBy):
 	url = "http://127.0.0.1:5000/notes/list"
 	return requests.get(url,headers=header, json={'list_field': listBy})
 
-def searchNotes(field, searchQuery, returnField, start=None, stop=None):
+def searchNotes(field, searchQuery, returnField, start='1970-01-01', stop=today.strftime("%Y-%m-%d")):
 	#by content, title, tags, date
 	url = "http://127.0.0.1:5000/notes/search"
 	# conditional check on whether to pass start and stop

--- a/apiCalls.py
+++ b/apiCalls.py
@@ -21,7 +21,7 @@ def searchNotes(field, searchQuery, returnField, start=None, stop=None):
 	#by content, title, tags, date
 	url = "http://127.0.0.1:5000/notes/search"
 	# conditional check on whether to pass start and stop
-	if field in set('modified_date', 'createNote'):
+	if field in set('modified_date', 'created_date'):
 		json = {'search_field': field, 'query': searchQuery, 'return_fields': returnField, 'start': start, 'stop': stop}
 	else:
 		json = {'search_field': field, 'query': searchQuery, 'return_fields': returnField}

--- a/app.py
+++ b/app.py
@@ -293,15 +293,32 @@ def search_notes():
                     FROM notes 
                     WHERE notes.content == '{query}'
                     """
+
     # modified_date looks like 'YYYY-MM-DD'
     if search_field == 'modified_date':
-        start = datetime.strptime(query, '%Y-%m-%d')
-
+        start_query = payload.get('start')
+        end_query = payload.get('end')
+        start = datetime.strptime(start_query, '%Y-%m-%d')
+        end = datetime.strptime(end_query, '%Y-%m-%d')
         # Construct SQL query
         sql_query = f"""
                      SELECT {select_fields_string} FROM notes 
-                     WHERE created_date == '{start.strftime('%Y-%m-%d')}'
+                     WHERE modified_date >= '{start.strftime('%Y-%m-%d')}' AND modified_date <= '{end.strftime('%Y-%m-%d')}'
                      """
+
+    # created_date looks like 'YYYY-MM-DD'
+    if search_field == 'created_date':
+        start_query = payload.get('start')
+        end_query = payload.get('end')
+        start = datetime.strptime(start_query, '%Y-%m-%d')
+        end = datetime.strptime(end_query, '%Y-%m-%d')
+        start = datetime.strptime(query, '%Y-%m-%d')
+        # Construct SQL query
+        sql_query = f"""
+                     SELECT {select_fields_string} FROM notes 
+                     WHERE created_date >= '{start.strftime('%Y-%m-%d')}' AND created_date <= '{end.strftime('%Y-%m-%d')}
+                     """
+
     # title
     if search_field == 'title':
         sql_query = f"""
@@ -309,14 +326,6 @@ def search_notes():
                    FROM notes
                    WHERE notes.title == '{query}'
                    """
-    # created_date looks like 'YYYY-MM-DD'
-    if search_field == 'created_date':
-        start = datetime.strptime(query, '%Y-%m-%d')
-        # Construct SQL query
-        sql_query = f"""
-                     SELECT {select_fields_string} FROM notes 
-                     WHERE created_date >= '{start.strftime('%Y-%m-%d')}'
-                     """
 
     # tag (super hard ?)
     if search_field == 'tag':

--- a/frontend.py
+++ b/frontend.py
@@ -321,11 +321,15 @@ def runtime(state):
 		#created_date
 			case 132:
 				lineBreak(columns, getConfig(4))
-				printColor("Enter date created to search.",getConfig(2))
+				printColor("Enter the beginning of the date range to search by.",getConfig(2))
 				lineBreak(columns, getConfig(4))
-				search_by = input(": ")
+				start = input(": ")
+				lineBreak(columns, getConfig(4))
+				printColor("Enter the end of the date range to search by.",getConfig(2))
+				lineBreak(columns, getConfig(4))
+				end = input(": ")
 				desired_response = ['title','content','modified_date','created_date']
-				api_response = apiCalls.searchNotes('created_date', search_by, desired_response)
+				api_response = apiCalls.searchNotes('created_date', "", desired_response, start, end)
 				entries = translation(api_response.content)
 				entries = entries.replace(r'\n', '\n')
 				print(entries)
@@ -333,11 +337,15 @@ def runtime(state):
 		#modified_date
 			case 133:
 				lineBreak(columns, getConfig(4))
-				printColor("Enter date modified to search.",getConfig(2))
+				printColor("Enter the beginning of the date range to search by.",getConfig(2))
 				lineBreak(columns, getConfig(4))
-				search_by = input(": ")
+				start = input(": ")
+				lineBreak(columns, getConfig(4))
+				printColor("Enter the end of the date range to search by.",getConfig(2))
+				lineBreak(columns, getConfig(4))
+				end = input(": ")
 				desired_response = ['title','content','modified_date','created_date']
-				api_response = apiCalls.searchNotes('modified_date', search_by, desired_response)
+				api_response = apiCalls.searchNotes('modified_date', "", desired_response, start, end)
 				entries = translation(api_response.content)
 				entries = entries.replace(r'\n', '\n')
 				print(entries)


### PR DESCRIPTION
Closes Issue #40
This refactor required changes to four files:
- `API.md` : the "Additional Feature 1: Search notes by note content" section now includes mention of an optional "start" and "end" field for the body sent to the `/notes/search` endpoint
- `app.py` : search endpoint now supports `start` and `end` payload key values, which contain (you guessed it) the start and end dates for the search windows for both modified and created dates searches. Notice that we only check for the values of these keys if the search_field is one of the dates fields, otherwise we don't read it at all
- `apiCalls.py` : json for the calls to the search endpoint need to be variable now. if we see that the key is modified or created date, we need to include the start and end values. we do that by setting start and end equal to None type by default, so that they don't need to be included by the caller on the frontend, but can be.
- `frontend.py` : now we need to ask the user for two values whenever they run the modified and created date case: the start and end date by which to search.