### PR TITLE
fix: apiCalls (messed up set notation)

### DIFF
--- a/apiCalls.py
+++ b/apiCalls.py
@@ -22,7 +22,7 @@ def searchNotes(field, searchQuery, returnField, start='1970-01-01', stop=date.t
 	#by content, title, tags, date
 	url = "http://127.0.0.1:5000/notes/search"
 	# conditional check on whether to pass start and stop
-	if field in set('modified_date', 'created_date'):
+	if field in set(['modified_date', 'created_date']):
 		json = {'search_field': field, 'query': searchQuery, 'return_fields': returnField, 'start': start, 'stop': stop}
 	else:
 		json = {'search_field': field, 'query': searchQuery, 'return_fields': returnField}


### PR DESCRIPTION
Hey all,

#51 screwed up `apiCalls.py` because of an error with my set notation. I wrote a line that said:

`assert "this_string" in set("this string", "that string")`

Instead of passing a list of the correct values like this:

`assert "this_string" in set(["this string", "that string"])`

Which threw the following error:

raceback (most recent call last):
```
  File "/Software-Engineering-Note-Taking-Application/frontend.py", line 566, in <module>
    runtime(0)
  File "/Software Development/Software-Engineering-Note-Taking-Application/frontend.py", line 285, in runtime
    api_response = apiCalls.searchNotes('title', search_by, desired_response)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "t/Software-Engineering-Note-Taking-Application/apiCalls.py", line 25, in searchNotes
    if field in set('modified_date', 'created_date'):
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: set expected at most 1 argument, got 2

```

All fixed with one easy tweak. For time reasons I will merge this on my own!

