### PR TITLE
fix: add defaults to the backend call for search by date

### DIFF
--- a/app.py
+++ b/app.py
@@ -307,8 +307,21 @@ def search_notes():
 
     # modified_date looks like 'YYYY-MM-DD'
     if search_field == 'modified_date':
-        start_query = payload.get('start')
-        end_query = payload.get('end')
+        # defaults
+        try: 
+            start_query = payload.get('start')
+            if start_query is None: 
+                start_query = '1970-01-01'
+        except KeyError as error:
+            start_query = '1970-01-01'
+        
+        try: 
+            end_query = payload.get('start')
+            if end_query is None: 
+                end_query = datetime.date.today().strftime('%Y-%m-%d')
+        except KeyError as error:
+            end_query = datetime.date.today().strftime('%Y-%m-%d')
+        
         start = datetime.strptime(start_query, '%Y-%m-%d')
         end = datetime.strptime(end_query, '%Y-%m-%d')
         # Construct SQL query
@@ -319,8 +332,21 @@ def search_notes():
 
     # created_date looks like 'YYYY-MM-DD'
     if search_field == 'created_date':
-        start_query = payload.get('start')
-        end_query = payload.get('end')
+        # defaults
+        try: 
+            start_query = payload.get('start')
+            if start_query is None: 
+                start_query = '1970-01-01'
+        except KeyError as error:
+            start_query = '1970-01-01'
+        
+        try: 
+            end_query = payload.get('start')
+            if end_query is None: 
+                end_query = datetime.date.today().strftime('%Y-%m-%d')
+        except KeyError as error:
+            end_query = datetime.date.today().strftime('%Y-%m-%d')
+        
         start = datetime.strptime(start_query, '%Y-%m-%d')
         end = datetime.strptime(end_query, '%Y-%m-%d')
         start = datetime.strptime(query, '%Y-%m-%d')


### PR DESCRIPTION
Resolves #64 
# Goal
This PR attempts to resolve the bugs Trent and Chris are having while testing the new backend functionality. 
# Features Added
I have added default start and end dates to the modified and created date calls in the `backend.py` search function itself, rather than relying on `apiCalls.py` to do the checking for me. I don't know what function was being called based on info being presented to me in #64 . I did not get exact traceback pastes so I can't tell what function is giving the error specified. However, I suspect they are running `app.py` from outside the `apiCalls.py` 

# Notes
In that issue Chris tried to call search with a date in format YYYY-MM-DD with value 0000-00-00 and he was surprised to get an error! `ValueError: time data '0000-00-00' does not match format '%Y-%m-%d'` 0000-00-00 is returned with an error because the datetime package knows that is an invalid date